### PR TITLE
Added sql that adds missing postgres role.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
         - "5435:5432"
         volumes:
         - ./data/db:/var/lib/postgresql/data
+        - ./postgresql/init.sql:/docker-entrypoint-initdb.d/init.sql
 
     solr:
         build: solr7/
@@ -53,3 +54,4 @@ services:
 networks:
   dvn:
     driver: bridge
+

--- a/postgresql/init.sql
+++ b/postgresql/init.sql
@@ -1,0 +1,1 @@
+CREATE ROLE postgres LOGIN;


### PR DESCRIPTION
I've tried many different ways and I managed to make this work with this solution.
The sql is automatically executed by the database after container boots up.  