### PR TITLE
Include the init.sql directly in the docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
         - "5435:5432"
         volumes:
         - ./data/db:/var/lib/postgresql/data
-        - ./postgresql/init.sql:/docker-entrypoint-initdb.d/init.sql
 
     solr:
         build: solr7/

--- a/postgresql/Dockerfile
+++ b/postgresql/Dockerfile
@@ -68,6 +68,8 @@ VOLUME /var/lib/postgresql/data
 COPY testdata /opt
 COPY init-postgres /opt
 COPY dvinstall.zip /opt
+COPY init.sql /docker-entrypoint-initdb.d/
+
 WORKDIR /opt
 RUN unzip dvinstall.zip
 WORKDIR /opt/dvinstall


### PR DESCRIPTION
See #22

Tests: building the postgresql by hand, making sure the init.sql is copied into the expected directory.