### PR TITLE
Run installation only if it not already installed

### DIFF
--- a/dataversedock/setupIT.bash
+++ b/dataversedock/setupIT.bash
@@ -12,27 +12,27 @@ if [ ! -e /opt/dv/status ]; then
 	unzip dvinstall.zip
 	patch -t /opt/dv/dvinstall/install < docker.patch
 	cd /opt/dv/dvinstall
-        /bin/mv -f /opt/dv/dataverse.war /opt/dv/dvinstall/dataverse.war
+	/bin/mv -f /opt/dv/dataverse.war /opt/dv/dvinstall/dataverse.war
 	/opt/glassfish4/glassfish/bin/asadmin start-domain
 	./install -admin_email=dataverseAdmin@mailinator.com -y -f
 #> install.out 2> install.err
 
 	cd /opt/dv/deps
-        /opt/glassfish4/glassfish/bin/asadmin create-jvm-options "\-Ddataverse.siteUrl=http\:\/\/demo.dataverse.org"
+	/opt/glassfish4/glassfish/bin/asadmin create-jvm-options "\-Ddataverse.siteUrl=http\:\/\/demo.dataverse.org"
 	echo "Applying language properties..."
 #	/opt/glassfish4/glassfish/bin/asadmin stop-domain
 #	sleep 10s
 #	cp -rf /opt/dv/$BUNDLEPROPERTIES /opt/glassfish4/glassfish/domains/domain1/applications/dataverse/WEB-INF/classes/Bundle.properties
 #	/opt/dv/langswitch.sh >> /opt/glassfish4/glassfish/domains/domain1/applications/dataverse/WEB-INF/classes/Bundle.properties
 #	/opt/glassfish4/glassfish/bin/asadmin start-domain
-        curl -X PUT -d 0 http://localhost:8080/api/admin/settings/:TabularIngestSizeLimit
+	curl -X PUT -d 0 http://localhost:8080/api/admin/settings/:TabularIngestSizeLimit
 	/opt/dv/dataverse-property-files/languageswitch.sh
 	/opt/glassfish4/glassfish/bin/asadmin deletecreate-jvm-options "\-Ddataverse.timerServer=true"
 	/opt/glassfish4/glassfish/bin/asadmin create-jvm-options "\-Ddataverse.timerServer=false"
-        /opt/glassfish4/glassfish/bin/asadmin delete-jvm-options '\-Ddataverse.files.directory=/opt/glassfish4/glassfish/domains/domain1/files'
-        /opt/glassfish4/bin/asadmin create-jvm-options '\-Ddataverse.files.directory=/opt/glassfish4/glassfish/domains/domain1/docroot/files'
+	/opt/glassfish4/glassfish/bin/asadmin delete-jvm-options '\-Ddataverse.files.directory=/opt/glassfish4/glassfish/domains/domain1/files'
+	/opt/glassfish4/bin/asadmin create-jvm-options '\-Ddataverse.files.directory=/opt/glassfish4/glassfish/domains/domain1/docroot/files'
 
 #	echo "Cleaning up installation files"
 #	rm -rf /opt/dv/*
-#	echo "Dataverse installed" > /opt/dv/status
+	echo "Dataverse installed" > /opt/dv/status
 fi


### PR DESCRIPTION
There is a problem, that entry script every time install Dataverse when it starts to run. This pull request allows the first run, and prevents subsequent runs, be adding a simple file check. The installation creates a new file, and if this file exists, the installation doesn't run again. All the code were available in the repository, but commented. I just uncommented a specific line.