### PR TITLE
add useremail setting to example .env file

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -33,6 +33,9 @@ hostname=locahost:8080
 traefikhost=localhost:8080
 INIT_SCRIPTS_FOLDER=/opt/payara/init.d
 
+# traefik email settings
+useremail=youremail@domain.com
+
 # Webhook configuration to bundle external services 
 WEBHOOK=/opt/payara/triggers/external-services.py
 #CESSDA=True


### PR DESCRIPTION
The `${useremail}` variable is set in `docker-compose.yml` but it is not included in `.env_sample`.  Without it, `docker-compose up -d` fails to start.